### PR TITLE
마이페이지 댓글 목록 기능 추가

### DIFF
--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -2,15 +2,20 @@
 {% load static %}
 
 {% block content %}
+
 <section id="portfolio">
+  <br><h1>Mypage</h1>
   <div class="container">
-    <h1>Mypage</h1>
+    <h3>Post</h3>
     <div class="row">
       <div class="col-md-12 col-sm-12">
-          <div class="iso-box-section wow fadeInUp" data-wow-delay="1s">
+        <div class="iso-section wow fadeInUp" data-wow-delay="0.3s">
+          <div class="iso-box-section wow fadeInUp" data-wow-delay="0.3s">
             <div class="iso-box-wrapper col4-iso-box">
               {% for post in posts %}
-              <div class="wow fadeInUp col-md-4 col-sm-4" data-wow-delay="0.3s">
+              <div
+                class="iso-box boxxxx club col-md-3 col-sm-3"
+                data-wow-delay="0.3s">
                 <div class="blog-thumb">
                   <img
                       src="{% static 'images/simbathon.jpg' %}"
@@ -32,4 +37,38 @@
     </div>
   </div>
 </section>
+
+<section id="portfolio">
+  <div class="container">
+    <h3>Comment</h3>
+    <div class="row">
+      <div class="col-md-12 col-sm-12">
+        <div class="iso-section wow fadeInUp" data-wow-delay="0.3s">
+          <div class="iso-box-section wow fadeInUp" data-wow-delay="0.3s">
+            <div class="iso-box-wrapper col4-iso-box">
+              {% for comment in comments %}
+              <div
+                class="iso-box boxxxx club col-md-3 col-sm-3"
+                data-wow-delay="0.3s">
+                <div class="blog-thumb">
+                  <h2 style="word-break: break-all; color:black;">{{comment.content|truncatechars:7}}</h2>
+                  <div class="post-format">
+                    <span>{{comment.post.title}} : {{comment.post.writer}}</span>
+                  </div>
+                  <div class="btn-detail">
+                    <a
+                      href="{% url 'ideathon:detail' comment.post.id %}"
+                      class="upload-btn">Details</a>
+                  </div>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 {% endblock %}

--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -21,7 +21,7 @@
                       src="{% static 'images/simbathon.jpg' %}"
                       class="img-responsive"
                       alt="Blog"/>
-                  <h2 style="word-break: break-all; color:black;">{{post.title}}</h2>
+                  <h2 style="word-break: break-all; color:black;">{{post.title|truncatechars:15}}</h2>
                   <div class="btn-detail">
                     <a
                       href="{% url 'ideathon:detail' post.id %}"
@@ -53,7 +53,7 @@
                 <div class="blog-thumb">
                   <h2 style="word-break: break-all; color:black;">{{comment.content|truncatechars:7}}</h2>
                   <div class="post-format">
-                    <span>{{comment.post.title}} : {{comment.post.writer}}</span>
+                    <span>{{comment.post.title|truncatechars:9}} : {{comment.post.writer}}</span>
                   </div>
                   <div class="btn-detail">
                     <a

--- a/users/views.py
+++ b/users/views.py
@@ -1,9 +1,10 @@
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.models import User
-from ideathon.models import Post
+from ideathon.models import Post, Comment
 
 
 def mypage(request):
   user = request.user
   posts = Post.objects.filter(writer=user)
-  return render(request, 'users/mypage.html', {'user':user, 'posts':posts})
+  comments = Comment.objects.filter(writer=user)
+  return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments})


### PR DESCRIPTION
1. 댓글 목록을 볼 수 있는 기능 추가
- 댓글 : 길이 넘어가면 ...
- 글 제목과 글쓴이 출력
- detail 누르면 해당 글로 이동


2. 반응형에 문제 있어서 아이디어톤 메인 부분 쪽 다시 긁어서 사용


![image](https://user-images.githubusercontent.com/64943924/119232861-a470a680-bb61-11eb-8f7a-9c4dd7591aef.png)
