### PR TITLE
feat: Fix mypage comment post writer name

### DIFF
--- a/ideathon/templates/ideathon/detail.html
+++ b/ideathon/templates/ideathon/detail.html
@@ -104,7 +104,7 @@
           <div class="blog-comment content">
             <div class="media">
               <div class="media-body">
-                <p class="media-heading">{{post.writer.last_name}}{{post.writer.first_name}}</p>
+                <p class="media-heading">{{comment.writer.last_name}}{{comment.writer.first_name}}</p>
                 <h5>
                   {{ comment.content|linebreaksbr }}
                 </h5>

--- a/ideathon/templates/ideathon/detail.html
+++ b/ideathon/templates/ideathon/detail.html
@@ -34,7 +34,7 @@
         </div>
         <div class="project-info">
           <h4>Writer</h4>
-          <p>{{post.writer.last_name}} {{post.writer.first_name}}</p>
+          <p>{{post.writer.last_name}}{{post.writer.first_name}}</p>
         </div>
         <div class="project-info">
           <h4>Date</h4>
@@ -104,7 +104,7 @@
           <div class="blog-comment content">
             <div class="media">
               <div class="media-body">
-                <p class="media-heading">{{ comment.writer }}</p>
+                <p class="media-heading">{{post.writer.last_name}}{{post.writer.first_name}}</p>
                 <h5>
                   {{ comment.content|linebreaksbr }}
                 </h5>

--- a/ideathon/templates/ideathon/update_comment.html
+++ b/ideathon/templates/ideathon/update_comment.html
@@ -26,9 +26,7 @@
             name="content"
             required
             id="comment"
-          >
-            {{comment.content}} 
-          </textarea>
+          >{{comment.content}}</textarea>
           <div class="contact-submit input">
             <input
               name="submit"

--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -66,7 +66,7 @@
                   <div class="post-format">
                     <span
                       >{{comment.post.title|truncatechars:9}} :
-                      {{comment.post.writer}}</span
+                      {{comment.post.writer.last_name}}{{comment.post.writer.first_name}}</span
                     >
                   </div>
                   <div class="btn-detail">


### PR DESCRIPTION
1. 마이페이지에서 댓글목록에 글 작성한 유저 아이디가 아닌 이름이 보이도록 수정
2. 글에서 댓글 작성자 이름으로 보이도록 수정
3. 댓글 수정시 빈칸 없게 수정