### PR TITLE
Member 모델추가, 마이페이지에서 멤버로 추가된 글 확인

### DIFF
--- a/hackerthon/models.py
+++ b/hackerthon/models.py
@@ -23,3 +23,7 @@ class Result(models.Model):
 
     def file_name(self):
         return self.introduction.name[11:].split('.')[-2]
+
+class Member(models.Model):
+    result = models.ForeignKey(Result, on_delete = models.CASCADE, related_name='members')
+    member = models.CharField(max_length=10)

--- a/hackerthon/templates/hackerthon/detail.html
+++ b/hackerthon/templates/hackerthon/detail.html
@@ -82,6 +82,51 @@
         </div>
       </div>
     </div>
+
+    <div class="row">
+      <div class="
+          wow
+          fadeInUp
+          col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10
+          container
+        " data-wow-delay="1s">
+        {% if user == post.writer %}
+        <div class="blog-comment-form">
+          <h3>Leave a member</h3>
+          <form action="{% url 'hackerthon:create_member' post.id %}" method="post">
+            {% csrf_token %}
+            <label>제목</label>
+            <input type="text" class="form-control mb-30" name="member" placeholder="Member" id="member" maxlength="10"required/>
+            <div class="contact-submit input">
+              <input name="submit" type="submit" class="form-control" id="submit" value="작성완료" />
+            </div>
+          </form>
+        </div>
+        {% endif %}
+
+        <div class="blog-comment">
+          <h4>Members</h4>
+          {% for member in members %}
+          <div class="blog-comment content">
+            <div class="media">
+              <div class="media-body">
+                <span class="line-content">{{ member.member }}</span>
+                <div class="date-btn">
+                  {% if user == post.writer %}
+                  <div class="button">
+                    <div class="project-info url comment">
+                      <a href="{% url 'hackerthon:delete_member' post.id member.pk %}">삭제</a>
+                    </div>
+                  </div>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/hackerthon/urls.py
+++ b/hackerthon/urls.py
@@ -10,4 +10,7 @@ urlpatterns =[
     path('<int:id>/', views.detail, name="detail"),
     path('update/<int:id>/', views.update, name="update"),
     path('delete/<int:id>/', views.delete, name="delete"),
+    #member
+    path('<int:id>/create_member', views.create_member, name="create_member"),
+    path('<int:id>/<int:member_id>/delete_member', views.delete_member, name="delete_member"),
 ]

--- a/hackerthon/views.py
+++ b/hackerthon/views.py
@@ -26,7 +26,8 @@ def create(request):
 
 def detail(request, id):
     post = get_object_or_404(Result, pk=id)
-    return render(request, 'hackerthon/detail.html', {'post':post}) 
+    all_members = post.members.all()
+    return render(request, 'hackerthon/detail.html', {'post':post, 'members':all_members}) 
 
 @login_required
 def update(request, id):
@@ -50,3 +51,16 @@ def delete(request, id):
     post = get_object_or_404(Result, pk=id)
     post.delete()
     return redirect("hackerthon:main")
+
+def create_member(request, id):
+    if request.method == "POST":
+        post = get_object_or_404(Result, pk=id)
+        member = request.POST['member']
+        Member.objects.create(result=post, member = member)
+    return redirect('hackerthon:detail', post.pk)
+
+def delete_member(request, id, member_id):
+    post = get_object_or_404(Result, pk=id)
+    member = get_object_or_404(Member, pk=member_id)
+    member.delete()
+    return redirect('hackerthon:detail', post.pk)

--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -38,6 +38,30 @@
                 </div>
               </div>
               {% endfor %}
+              {% for result in results %}
+              <div
+                class="iso-box boxxxx club col-md-3 col-sm-3"
+                data-wow-delay="0.3s"
+              >
+                <div class="blog-thumb">
+                  <img
+                    src="{% static 'images/simbathon.jpg' %}"
+                    class="img-responsive"
+                    alt="Blog"
+                  />
+                  <h2 style="word-break: break-all; color: black">
+                    {{result.title|truncatechars:15}}
+                  </h2>
+                  <div class="btn-detail">
+                    <a
+                      href="{% url 'hackerthon:detail' result.id %}"
+                      class="upload-btn"
+                      >Details</a
+                    >
+                  </div>
+                </div>
+              </div>
+              {% endfor %}
             </div>
           </div>
         </div>

--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -38,7 +38,7 @@
                 </div>
               </div>
               {% endfor %}
-              {% for result in results %}
+              {% if member %}
               <div
                 class="iso-box boxxxx club col-md-3 col-sm-3"
                 data-wow-delay="0.3s"
@@ -50,18 +50,18 @@
                     alt="Blog"
                   />
                   <h2 style="word-break: break-all; color: black">
-                    {{result.title|truncatechars:15}}
+                    {{member.result.title|truncatechars:15}}
                   </h2>
                   <div class="btn-detail">
                     <a
-                      href="{% url 'hackerthon:detail' result.id %}"
+                      href="{% url 'hackerthon:detail' member.result.pk %}"
                       class="upload-btn"
                       >Details</a
                     >
                   </div>
                 </div>
               </div>
-              {% endfor %}
+              {% endif %}
             </div>
           </div>
         </div>

--- a/users/views.py
+++ b/users/views.py
@@ -1,10 +1,12 @@
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.models import User
 from ideathon.models import Post, Comment
+from hackerthon.models import Result
 
 
 def mypage(request):
   user = request.user
   posts = Post.objects.filter(writer=user)
   comments = Comment.objects.filter(writer=user)
-  return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments})
+  results = Result.objects.filter(writer=user)
+  return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments, 'results':results})

--- a/users/views.py
+++ b/users/views.py
@@ -1,12 +1,15 @@
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.models import User
 from ideathon.models import Post, Comment
-from hackerthon.models import Result
+from hackerthon.models import *
 
 
 def mypage(request):
   user = request.user
   posts = Post.objects.filter(writer=user)
   comments = Comment.objects.filter(writer=user)
-  results = Result.objects.filter(writer=user)
-  return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments, 'results':results})
+  try:
+    member = Member.objects.get(member=user.last_name + user.first_name)
+    return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments, 'member':member})
+  except Member.DoesNotExist:
+    return render(request, 'users/mypage.html', {'user':user, 'posts':posts, 'comments':comments})


### PR DESCRIPTION
머지되면 migration 한번해야합니당

1. 해커톤 페이지에서 글 작성후 아래에 멤버 한명씩 이름으로만 추가해야합니다.
삭제만 넣고 수정 뺐습니다. 수정하는것보다 삭제하고 다시쓰는게 빠를 것 같아서 이렇게 짰습니다.
글 작성자가 자기 이름도 써 넣어야 마이페이지에서 확인됩니다.
![image](https://user-images.githubusercontent.com/64943924/123226547-b94cab00-d50e-11eb-8074-cc5b0b1f59a3.png)

2. 마이페이지에서는 아이디어톤 글 전부 -> 해커톤 글로 뜨도록 했고 어차피 해커톤 글은 한 개라서 for문 안돌리고 객체 하나 받아오는 걸로 처리했습니다. 그래서 멤버 여러 곳에 추가되면 예외처리 안해둬서 오류납니다. 공지할 때 반드시 글 작성자 본인 포함해서 팀 멤버 이름만 잘 적어서 등록하라고 해야함...
![image](https://user-images.githubusercontent.com/64943924/123226845-fadd5600-d50e-11eb-85df-175837bf5e6d.png)

3. 로그아웃 한 상태거나 내가 쓴 글이 아닌 글의 멤버는 아래처럼 입력과 삭제 못하게 막았습니다. 
![image](https://user-images.githubusercontent.com/64943924/123227583-ae464a80-d50f-11eb-8640-359c18b28ea0.png)

